### PR TITLE
Bugfix browser back

### DIFF
--- a/snsapp/admin.py
+++ b/snsapp/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
-from .models import Post, Connection
+from .models import Post, Comment, Connection
 
 # Register your models here.
 admin.site.register(Post)
+admin.site.register(Comment)
 admin.site.register(Connection)

--- a/static/js/browser-back-control.js
+++ b/static/js/browser-back-control.js
@@ -1,10 +1,10 @@
-// 直前に閲覧していたページのURLの末尾を取得
-var ref = document.referrer;
-var stringArray = ref.split('/');
-// 編集画面から詳細画面に遷移した場合のみブラウザバックを禁止
-if ( stringArray[stringArray.length-1] == 'update' ) {
-  history.pushState(null, null, location.href);
-  window.addEventListener('popstate', (e) => {
-    history.go(1);
-  })
+// ブラウザバックを禁止
+// ※Google Chromeではフォーカスが一度でも当たっていないとブラウザバックできてしまう
+window.onload = function() {
+  history.pushState(null, null, null);
+
+  window.addEventListener("popstate", function (e) {
+    history.pushState(null, null, null);
+    return;
+  });
 };

--- a/static/js/browser-back-control.js
+++ b/static/js/browser-back-control.js
@@ -1,10 +1,12 @@
-// ブラウザバックを禁止
+// 新規投稿ページ，投稿編集ページ，コメント作成ページ以外のページでブラウザバックを禁止
 // ※Google Chromeではフォーカスが一度でも当たっていないとブラウザバックできてしまう
-window.onload = function() {
-  history.pushState(null, null, null);
-
-  window.addEventListener("popstate", function (e) {
+if !( document.URL.match(create) || document.URL.match(update) ){
+  window.onload = function() {
     history.pushState(null, null, null);
-    return;
-  });
-};
+
+    window.addEventListener("popstate", function (e) {
+      history.pushState(null, null, null);
+      return;
+    });
+  };
+}


### PR DESCRIPTION
# やったこと

新規投稿ページ，投稿編集ページ，コメント作成ページでのキャンセルボタンが反応しないバグを修正．

# 目的

キャンセルボタンを使えるようにする．

# できるようになったこと

- キャンセルボタンの使用

# できなくなったこと

- 特になし

# 動作確認

実際のページでキャンセルボタンが使えることを確認した．

# 懸念点

本当はすべてのページでブラウザバックを禁止したかったが，このバグを修正するにあたって該当ページでブラウザバックができるようにしたので，それに付随したバグが生じる可能性がある．