### PR TITLE
Feature create

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'accounts.apps.AccountsConfig',
     'snsapp.apps.SnsappConfig',
     'django_bootstrap5',
+    'widget_tweaks',
     'django.contrib.sites',
     'allauth',
     'allauth.account',

--- a/snsapp/forms.py
+++ b/snsapp/forms.py
@@ -1,0 +1,11 @@
+from django import forms
+from .models import Post
+
+
+class PostForm(forms.ModelForm):
+    """
+    新規投稿フォーム
+    """
+    class Meta:
+        model = Post
+        fields = ['title', 'content', 'image', 'url']

--- a/snsapp/urls.py
+++ b/snsapp/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import Home, MyPost, DetailPost
+from .views import Home, MyPost, DetailPost, CreatePost
 
 
 app_name = 'snsapp'
@@ -7,5 +7,6 @@ app_name = 'snsapp'
 urlpatterns = [
     path('', Home.as_view(), name='home'),
     path('mypost/', MyPost.as_view(), name='mypost'),
-    path('detail/<int:pk>', DetailPost.as_view(), name='detail')
+    path('detail/<int:pk>', DetailPost.as_view(), name='detail'),
+    path('create/', CreatePost.as_view(), name='create'),
 ]

--- a/snsapp/views.py
+++ b/snsapp/views.py
@@ -1,10 +1,14 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.views.generic import ListView, DetailView
+from django.urls import reverse_lazy
+from django.views.generic import ListView, DetailView, CreateView
+from .forms import PostForm
 from .models import Post
 
 
 class Home(LoginRequiredMixin, ListView):
-   """HOMEページで、自分以外のユーザー投稿をリスト表示"""
+   """
+   HOMEページで、自分以外のユーザの投稿をリスト表示
+   """
    model = Post
    template_name = 'list.html'
 
@@ -14,6 +18,9 @@ class Home(LoginRequiredMixin, ListView):
 
 
 class MyPost(LoginRequiredMixin, ListView):
+    """
+    HOMEページで、自分の投稿をリスト表示
+   """
     model = Post
     template_name = 'list.html'
 
@@ -23,5 +30,27 @@ class MyPost(LoginRequiredMixin, ListView):
 
 
 class DetailPost(LoginRequiredMixin, DetailView):
+    """
+    投稿の詳細を表示
+    """
     model = Post
     template_name = 'detail.html'
+
+
+class CreatePost(LoginRequiredMixin, CreateView):
+    """
+    新規投稿ページを表示
+    """
+    model = Post
+    template_name = 'create.html'
+    form_class = PostForm
+    success_url = reverse_lazy('snsapp:mypost')
+
+    def form_valid(self, form):
+        """
+        フォームの入力に成功した場合，投稿ユーザとリクエストユーザを紐付ける
+        """
+        post = form.save(commit=False)
+        post.user = self.request.user
+        post.save()
+        return super().form_valid(form)

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,6 +17,9 @@
             <div class="navbar-nav">
               <a class="nav-link" href="{% url 'snsapp:mypost' %}">mypost</a>
             </div>
+            <div class="navbar-nav">
+              <a class="nav-link" href="{% url 'snsapp:create' %}">create</a>
+            </div>
           </div>
       </div>
     </nav>

--- a/templates/create.html
+++ b/templates/create.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% load widget_tweaks %}
+
+
+{% block content %}
+<div class="container col-lg-6 offset-lg-3">
+    <div class="alert alert-success" role="alert">
+        <form method="post" enctype='multipart/form-data'>
+            {{ form.non_field_errors }}
+            {% for field in form %}
+            <div class="field">
+              {{ field.label_tag }}
+              {% render_field field class="form-control" %}
+              {{ field.errors }}
+            </div>
+            {% endfor %}
+            {% csrf_token %}
+            <div class="row my-3">
+                <button type="submit" class="btn btn-success col-3 offset-2">投稿</button>
+                <a class="btn btn-danger col-3 offset-2" href="#" onclick="history.back(-1);return false;">キャンセル</a>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
# やったこと

新規投稿機能の実装

# 目的

一般ユーザが新たに投稿を作成できるようにするため．

# できるようになったこと

- 新規投稿の作成

# できなくなったこと

- 特になし

# 動作確認

一般ユーザでログインして実際に投稿を作成したところ，正常に動作し，一覧ページに表示されることが確認できた．また，投稿完了後の遷移先も期待通りに自分の投稿ページになっていた．

# 懸念点

新たに投稿は作成できるが，既存の投稿の編集・削除はできないため，誤って投稿してしまった場合に不便である．そのため，編集・削除機能は早めに実装する予定．