### PR TITLE
fix: fix a bug where the destination was not immersed after editing

### DIFF
--- a/snsapp/views.py
+++ b/snsapp/views.py
@@ -54,7 +54,7 @@ class UpdatePost(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         編集完了後の遷移先
         """
         pk = self.kwargs['pk']
-        return reverse_lazy('detail', kwargs={'pk': pk})
+        return reverse_lazy('snsapp:detail', kwargs={'pk': pk})
 
     def test_func(self, **kwargs):
         """


### PR DESCRIPTION
# やったこと

UpdatePost内で編集後の遷移先を変更．

# 目的

編集後に遷移先が見つからないバグを修正するため．

# できるようになったこと

- 編集後に詳細ページに遷移

# できなくなったこと

- 特になし

# 動作確認

実際に投稿を編集し，完了後に詳細ページに遷移することを確認した．

# 懸念点

特になし．