### PR TITLE
Feature delete

### DIFF
--- a/snsapp/urls.py
+++ b/snsapp/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import Home, MyPost, DetailPost, UpdatePost, CreatePost
+from .views import Home, MyPost, DetailPost, UpdatePost, CreatePost, DeletePost
 
 
 app_name = 'snsapp'

--- a/snsapp/urls.py
+++ b/snsapp/urls.py
@@ -9,5 +9,6 @@ urlpatterns = [
     path('mypost/', MyPost.as_view(), name='mypost'),
     path('detail/<int:pk>', DetailPost.as_view(), name='detail'),
     path('detail/<int:pk>/update', UpdatePost.as_view(), name='update'),
+    path('detail/<int:pk>/delete', DeletePost.as_view(), name='delete'),
     path('create/', CreatePost.as_view(), name='create'),
 ]

--- a/snsapp/views.py
+++ b/snsapp/views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.urls import reverse_lazy
-from django.views.generic import ListView, DetailView, UpdateView, CreateView
+from django.views.generic import ListView, DetailView, UpdateView, CreateView, DeleteView
 from .forms import PostForm
 from .models import Post
 
@@ -82,3 +82,20 @@ class CreatePost(LoginRequiredMixin, CreateView):
         post.user = self.request.user
         post.save()
         return super().form_valid(form)
+
+
+class Deletepost(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
+    """
+    投稿削除ページを表示
+    """
+    model = Post
+    template_name = 'delete.html'
+    success_url = reverse_lazy('snsapp:mypost')
+
+    def test_func(self, **kwargs):
+        """
+        アクセスできるユーザを制限
+        """
+        pk = self.kwargs['pk']
+        post = Post.objects.get(pk=pk)
+        return post.user == self.request.user

--- a/snsapp/views.py
+++ b/snsapp/views.py
@@ -84,7 +84,7 @@ class CreatePost(LoginRequiredMixin, CreateView):
         return super().form_valid(form)
 
 
-class Deletepost(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
+class DeletePost(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
     """
     投稿削除ページを表示
     """

--- a/templates/delete.html
+++ b/templates/delete.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block content %}
+<div class="container mt-3">
+    <div class="alert alert-success" role="alert">
+        <form method="post">{% csrf_token %}
+            <p>本当に削除してもよろしいですか？</p>
+            <button type="submit" class="btn btn-success col-3 offset-2">削除</button>
+            <a class="btn btn-danger col-3 offset-2" href="#" onclick="history.back(-1);return false;">キャンセル</a>
+    </div>
+</div>
+{% endblock %}

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -17,6 +17,7 @@
 
         {% if object.user == request.user %}
             <a class="btn btn-primary" href="{% url 'snsapp:update' object.pk %}" role="button">編集</a>
+            <a class="btn btn-danger" href="{% url 'snsapp:delete' object.pk %}" role="button">削除</a>
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
# やったこと

自分の投稿を削除するためのページを作成した．

# 目的

何らかの理由で自分の投稿を削除したくなった場合に対応するため．

# できるようになったこと

- 自分の投稿の削除

# できなくなったこと

- 特になし

# 動作確認

既にある投稿を削除したところ削除でき，遷移先も正しいことが確認できた．また，自分以外の投稿の削除ページに遷移できないことも確認できた．

# 懸念点

誤って削除してしまった場合に，データベースからも削除されてしまうため復元ができない．ワンクリックで削除できないように，削除ページに遷移してから再度削除するかを尋ねるようにはしているが，それでも誤って削除してしまう場合があるかもしれない．今のところ，対策は考えていない．