### PR TITLE
perf: change to display the number of Likes on the button of the user…

### DIFF
--- a/templates/detail.html
+++ b/templates/detail.html
@@ -20,9 +20,9 @@
         {% endif %}
 
         {% if request.user in object.like_users.all %}
-        <a class="like-btn add-color" href="{% url 'snsapp:like-detail' object.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>{{object.like_users.count}}
+        <a class="like-btn add-color" href="{% url 'snsapp:like-detail' object.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>
         {% else %}
-        <a class="like-btn" href="{% url 'snsapp:like-detail' object.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>{{object.like_users.count}}
+        <a class="like-btn" href="{% url 'snsapp:like-detail' object.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>
         {% endif %}
 
         {% if object.user == request.user %}
@@ -30,7 +30,7 @@
             <a class="btn btn-danger" href="{% url 'snsapp:delete' object.pk %}" role="button">削除</a>
         {% endif %}
 
-        <button type="button" class="btn btn-danger dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">いいねした人</button>
+        <button type="button" class="btn btn-danger dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">いいね {{object.like_users.count}}</button>
         <ul class="dropdown-menu">
             <!-- いいねしたユーザが１人でもいる場合 -->
             {% if object.like_users.all %}

--- a/templates/list.html
+++ b/templates/list.html
@@ -22,14 +22,14 @@
 
 
         {% if request.user in item.like_users.all %}
-        <a class="like-btn add-color" href="{% url 'snsapp:like-home' item.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>{{item.like_users.count}}
+        <a class="like-btn add-color" href="{% url 'snsapp:like-home' item.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>
         {% else %}
-        <a class="like-btn" href="{% url 'snsapp:like-home' item.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>{{item.like_users.count}}
+        <a class="like-btn" href="{% url 'snsapp:like-home' item.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>
         {% endif %}
 
         <a class="btn btn-primary" href="{% url 'snsapp:detail' item.pk %}" role="button">詳細</a>
 
-        <button type="button" class="btn btn-danger dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">いいねした人</button>
+        <button type="button" class="btn btn-danger dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">いいね {{item.like_users.count}}</button>
         <ul class="dropdown-menu">
             <!-- いいねしたユーザが１人でもいる場合 -->
             {% if item.like_users.all %}


### PR DESCRIPTION
# やったこと

いいね数をいいねユーザの一覧ボタン上に表示するようにした．

# 目的

いいねボタンの隣に数字だけが置かれているのは少し違和感があることと，いいね数が増えて桁が変化するたびにボタンが右に移動してしまうため．

# できるようになったこと

- いいねをすることといいねの状況確認の分離

# できなくなったこと

- 特になし

# 動作確認

いいね数の表示場所が意図した通りになっていることが確認できた．

# 懸念点

特になし．