### PR TITLE
Feature profile

### DIFF
--- a/snsapp/forms.py
+++ b/snsapp/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from accounts.models import User
 from .models import Post
 
 
@@ -9,3 +10,12 @@ class PostForm(forms.ModelForm):
     class Meta:
         model = Post
         fields = ['title', 'content', 'image', 'url']
+
+
+class ProfileForm(forms.ModelForm):
+    """
+    プロフィール更新フォーム
+    """
+    class Meta:
+        model = User
+        fields = ['nickname', 'image', 'introduction', 'url']

--- a/snsapp/urls.py
+++ b/snsapp/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import Home, MyPost, CreatePost, DetailPost, UpdatePost, DeletePost, LikeHome, LikeDetail, FollowHome, FollowDetail, FollowList
+from .views import Home, MyPost, CreatePost, DetailPost, UpdatePost, DeletePost, LikeHome, LikeDetail, FollowHome, FollowDetail, FollowList, Profile
 
 
 app_name = 'snsapp'
@@ -16,4 +16,5 @@ urlpatterns = [
     path('follow-home/<int:pk>', FollowHome.as_view(), name='follow-home'),
     path('follow-detail/<int:pk>', FollowDetail.as_view(), name='follow-detail'),
     path('follow-list', FollowList.as_view(), name='follow-list'),
+    path('profile/<slug:username>', Profile.as_view(), name='profile'),
 ]

--- a/snsapp/urls.py
+++ b/snsapp/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import Home, MyPost, CreatePost, DetailPost, UpdatePost, DeletePost, LikeHome, LikeDetail, FollowHome, FollowDetail, FollowList, Profile, UpdateProfile
+from .views import Home, MyPost, CreatePost, DetailPost, UpdatePost, DeletePost, LikeHome, LikeDetail, FollowHome, FollowDetail, FollowProfile, FollowList, Profile, UpdateProfile
 
 
 app_name = 'snsapp'
@@ -15,6 +15,7 @@ urlpatterns = [
     path('like-detail/<int:pk>', LikeDetail.as_view(), name='like-detail'),
     path('follow-home/<int:pk>', FollowHome.as_view(), name='follow-home'),
     path('follow-detail/<int:pk>', FollowDetail.as_view(), name='follow-detail'),
+    path('follow-profile/<slug:username>', FollowProfile.as_view(), name='follow-profile'),
     path('follow-list', FollowList.as_view(), name='follow-list'),
     path('profile/<slug:username>', Profile.as_view(), name='profile'),
     path('profile/<int:pk>/update', UpdateProfile.as_view(), name='profile-update'),

--- a/snsapp/urls.py
+++ b/snsapp/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import Home, MyPost, CreatePost, DetailPost, UpdatePost, DeletePost, LikeHome, LikeDetail, FollowHome, FollowDetail, FollowList, Profile
+from .views import Home, MyPost, CreatePost, DetailPost, UpdatePost, DeletePost, LikeHome, LikeDetail, FollowHome, FollowDetail, FollowList, Profile, UpdateProfile
 
 
 app_name = 'snsapp'
@@ -17,4 +17,5 @@ urlpatterns = [
     path('follow-detail/<int:pk>', FollowDetail.as_view(), name='follow-detail'),
     path('follow-list', FollowList.as_view(), name='follow-list'),
     path('profile/<slug:username>', Profile.as_view(), name='profile'),
+    path('profile/<int:pk>/update', UpdateProfile.as_view(), name='profile-update'),
 ]

--- a/snsapp/views.py
+++ b/snsapp/views.py
@@ -4,7 +4,7 @@ from django.urls import reverse_lazy
 from django.views import View
 from django.views.generic import ListView, DetailView, UpdateView, CreateView, DeleteView
 from accounts.models import User
-from .forms import PostForm
+from .forms import PostForm, ProfileForm
 from .models import Post, Connection
 
 
@@ -251,3 +251,28 @@ class Profile(LoginRequiredMixin, ListView):
         # 現在のページのURLからユーザ名を取得
         username = self.request.path.split('/')[-1]
         return User.objects.filter(username=username)
+
+
+class UpdateProfile(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
+    """
+    プロフィール更新ページ
+    """
+    model = User
+    template_name = 'update.html'
+    form_class = ProfileForm
+
+    def get_success_url(self, **kwargs):
+        """
+        更新完了後の遷移先
+        """
+        # 自身のユーザ名を取得
+        id = self.request.user.id
+        return reverse_lazy('snsapp:profile', kwargs={'id': id})
+
+    def test_func(self, **kwargs):
+        """
+        アクセスできるユーザを制限
+        """
+        pk = self.kwargs['pk']
+        user = User.objects.get(pk=pk)
+        return user == self.request.user

--- a/snsapp/views.py
+++ b/snsapp/views.py
@@ -310,8 +310,8 @@ class UpdateProfile(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         更新完了後の遷移先
         """
         # 自身のユーザ名を取得
-        id = self.request.user.id
-        return reverse_lazy('snsapp:profile', kwargs={'id': id})
+        username = self.request.user.username
+        return reverse_lazy('snsapp:profile', kwargs={'username': username})
 
     def test_func(self, **kwargs):
         """

--- a/snsapp/views.py
+++ b/snsapp/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views import View
 from django.views.generic import ListView, DetailView, UpdateView, CreateView, DeleteView
-# from accounts.models import User
+from accounts.models import User
 from .forms import PostForm
 from .models import Post, Connection
 
@@ -236,3 +236,18 @@ class FollowList(LoginRequiredMixin, ListView):
         context['connection'] = Connection.objects.get_or_create(user=self.request.user)
         return context
 
+
+class Profile(LoginRequiredMixin, ListView):
+    """
+    特定のユーザのユーザ情報をリスト表示
+    """
+    model = User
+    template_name = 'profile.html'
+
+    def get_queryset(self):
+        """
+        ユーザ情報を取得
+        """
+        # 現在のページのURLからユーザ名を取得
+        username = self.request.path.split('/')[-1]
+        return User.objects.filter(username=username)

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,9 @@
         <a class="navbar-brand" href="{% url 'snsapp:home' %}">Home</a>
         <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
             <div class="navbar-nav">
+              <a class="nav-link" href="{% url 'snsapp:profile' request.user.username %}">myprofile</a>
+            </div>
+            <div class="navbar-nav">
               <a class="nav-link" href="{% url 'snsapp:mypost' %}">mypost</a>
             </div>
             <div class="navbar-nav">

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -10,7 +10,7 @@
 <div class="container mt-3">
     <div class="alert alert-success" role="alert">
         <p>タイトル：{{object.title}}</p>
-        <p>投稿者：{{object.user.username}}</p>
+        <p>投稿者：<a href="{% url 'snsapp:profile' object.user.username %}">{{object.user.username}}</a></p>
         <P>本文：{{object.content}}</P>
         {% if object.image %}
             <p>画像：{{object.image}}</p>

--- a/templates/list.html
+++ b/templates/list.html
@@ -11,7 +11,7 @@
     {% for item in object_list %}
     <div class="alert alert-success" role="alert">
         <p>タイトル：{{item.title}}</p>
-        <p>投稿者：{{item.user.username}}</p>
+        <p>投稿者：<a href="{% url 'snsapp:profile' item.user.username %}">{{item.user.username}}</a></p>
         <!-- <P>本文：{{item.content}}</P>
         {% if item.image %}
             <P>画像：{{item.image}}</P>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block customcss %}
+    <link rel="stylesheet" href="{% static 'style.css' %}">
+{% endblock customcss %}
+
+
+{% block content %}
+<div class="container mt-3">
+    {% for item in object_list %}
+    <div class="alert alert-success" role="alert">
+        <p>ユーザ名：{{item.username}}</p>
+        <p>ニックネーム：{{item.nickname}}</p>
+        <p>メールアドレス：{{item.email}}</p>
+        <p>アイコン：{{item.image}}</p>
+        <p>自己紹介：{{item.introduction}}</p>
+        <p>URL：{{item.url}}</p>
+    </div>
+    {% endfor %}
+</div>
+{% endblock content %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -10,9 +10,7 @@
 <div class="container mt-3">
     {% for item in object_list %}
     <div class="alert alert-success" role="alert">
-        <p>ユーザ名：{{item.username}}</p>
         <p>ニックネーム：{{item.nickname}}</p>
-        <p>メールアドレス：{{item.email}}</p>
         <p>アイコン：{{item.image}}</p>
         <p>自己紹介：{{item.introduction}}</p>
         <p>URL：{{item.url}}</p>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -17,6 +17,12 @@
 
             {% if user == request.user %}
             <a class="btn btn-primary" href="{% url 'snsapp:profile-update' request.user.pk %}" role="button">編集</a>
+            {% else %}
+                {% if user in connection.0.following.all %}
+                    <a class="btn btn-success" href="{% url 'snsapp:follow-profile' user.username %}" role="button">フォロー解除</a>
+                {% else %}
+                    <a class="btn btn-success" href="{% url 'snsapp:follow-profile' user.username %}" role="button">フォロー</a>
+                {% endif %}
             {% endif %}
 
         {% endfor %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -8,13 +8,19 @@
 
 {% block content %}
 <div class="container mt-3">
-    {% for item in object_list %}
     <div class="alert alert-success" role="alert">
-        <p>ニックネーム：{{item.nickname}}</p>
-        <p>アイコン：{{item.image}}</p>
-        <p>自己紹介：{{item.introduction}}</p>
-        <p>URL：{{item.url}}</p>
+        {% for user in object_list %}
+            <p>ニックネーム：{{user.nickname}}</p>
+            <p>アイコン：{{user.image}}</p>
+            <p>自己紹介：{{user.introduction}}</p>
+            <p>URL：{{user.url}}</p>
+
+            {% if user == request.user %}
+            <a class="btn btn-primary" href="{% url 'snsapp:profile-update' request.user.pk %}" role="button">編集</a>
+            {% endif %}
+
+        {% endfor %}
+
     </div>
-    {% endfor %}
 </div>
 {% endblock content %}


### PR DESCRIPTION
# やったこと

ユーザごとに固有のプロフィールページを持ち，それに他のユーザがアクセスできるようにした．

# 目的

特定のユーザの自己紹介や他のSNSのURLなどの情報を知りたいというニーズに応えるため．

# できるようになったこと

- プロフィールページを持つこと
- プロフィールページの更新
- プロフィールページヘのアクセス
- プロフィールページでのフォロー・フォロー解除

# できなくなったこと

- 特になし

# 動作確認

実際にプロフィールページへのアクセス，更新とプロフィールページでのフォローを行い，正常に動作することが確認できた．

# 懸念点

プロフィールの埋まっていない情報については"None"と表示されるようになっているが，この表示は無機質すぎるため，変更したほうが良いと思われる．また，TwitterやInstagramなどのようにフォロー・フォロワーも表示できるようにしたい．