### PR TITLE
Feature profile

### DIFF
--- a/snsapp/urls.py
+++ b/snsapp/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import Home, MyPost, CreatePost, DetailPost, UpdatePost, DeletePost, LikeHome, LikeDetail, FollowHome, FollowDetail, FollowProfile, FollowList, Profile, UpdateProfile
+from .views import Home, MyPost, CreatePost, DetailPost, UpdatePost, DeletePost, LikeHome, LikeDetail, LikeProfile, FollowHome, FollowDetail, FollowProfile, FollowList, Profile, UpdateProfile
 
 
 app_name = 'snsapp'
@@ -13,6 +13,7 @@ urlpatterns = [
     path('detail/<int:pk>/delete', DeletePost.as_view(), name='delete'),
     path('like-home/<int:pk>', LikeHome.as_view(), name='like-home'),
     path('like-detail/<int:pk>', LikeDetail.as_view(), name='like-detail'),
+    path('like-profile/<int:pk>', LikeProfile.as_view(), name='like-profile'),
     path('follow-home/<int:pk>', FollowHome.as_view(), name='follow-home'),
     path('follow-detail/<int:pk>', FollowDetail.as_view(), name='follow-detail'),
     path('follow-profile/<slug:username>', FollowProfile.as_view(), name='follow-profile'),

--- a/snsapp/views.py
+++ b/snsapp/views.py
@@ -124,7 +124,7 @@ class DeletePost(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
 
 class LikeBase(LoginRequiredMixin, View):
     """
-    いいねのベース．データベースとのやり取りを定義．
+    投稿ページでのいいねのベース．データベースとのやり取りを定義．
     リダイレクト先は継承先のViewで決定
     """
     def get(self, request, *args, **kwargs):
@@ -165,9 +165,23 @@ class LikeDetail(LikeBase):
         return redirect('snsapp:detail', pk)
 
 
+class LikeProfile(LikeBase):
+    """
+    プロフィールページでいいねした場合
+    """
+    def get(self, request, *args, **kwargs):
+        # LikeBaseのobjを継承
+        super().get(request, *args, **kwargs)
+        # 投稿からユーザ名を特定
+        pk = self.kwargs['pk']
+        username = Post.objects.get(pk=pk).user.username
+        # profileにリダイレクト
+        return redirect('snsapp:profile', username)
+
+
 class FollowBaseOnPost(LoginRequiredMixin, View):
     """
-    投稿からのフォローのベース．データベースとのやり取りを定義．
+    投稿ページでのフォローのベース．データベースとのやり取りを定義．
     リダイレクト先は継承先のViewで決定
     """
     def get(self, request, *args, **kwargs):
@@ -213,7 +227,7 @@ class FollowDetail(FollowBaseOnPost):
 
 class FollowBaseOnProfile(LoginRequiredMixin, View):
     """
-    プロフィールページからのフォローのベース．データベースとのやり取りを定義．
+    プロフィールページでのフォローのベース．データベースとのやり取りを定義．
     リダイレクト先は継承先のViewで決定
     """
     def get(self, request, *args, **kwargs):

--- a/snsapp/views.py
+++ b/snsapp/views.py
@@ -279,12 +279,17 @@ class Profile(LoginRequiredMixin, ListView):
     model = User
     template_name = 'profile.html'
 
+    def get_username(self):
+        """
+        現在のページのURLからユーザ名を取得
+        """
+        return self.request.path.split('/')[-1]
+
     def get_queryset(self):
         """
         ユーザ情報を取得
         """
-        # 現在のページのURLからユーザ名を取得
-        username = self.request.path.split('/')[-1]
+        username = self.get_username()
         return User.objects.filter(username=username)
 
     def get_context_data(self, *args, **kwargs):
@@ -292,7 +297,11 @@ class Profile(LoginRequiredMixin, ListView):
         コネクションに関するオブジェクト情報をコンテクストに追加
         """
         context = super().get_context_data(*args, **kwargs)
-        # コンテクストに追加
+        # ユーザ名からユーザを特定
+        username = self.get_username()
+        user = User.objects.get(username=username)
+        # 投稿とコネクション情報をコンテクストに追加
+        context['posts'] = Post.objects.filter(user=user)
         context['connection'] = Connection.objects.get_or_create(user=self.request.user)
         return context
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -36,9 +36,9 @@
         <p>投稿者：<a href="{% url 'snsapp:profile' post.user.username %}">{{post.user.username}}</a></p>
 
         {% if request.user in post.like_users.all %}
-        <a class="like-btn add-color" href="{% url 'snsapp:like-home' post.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>
+        <a class="like-btn add-color" href="{% url 'snsapp:like-profile' post.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>
         {% else %}
-        <a class="like-btn" href="{% url 'snsapp:like-home' post.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>
+        <a class="like-btn" href="{% url 'snsapp:like-profile' post.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>
         {% endif %}
 
         <a class="btn btn-primary" href="{% url 'snsapp:detail' post.pk %}" role="button">詳細</a>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -24,9 +24,41 @@
                     <a class="btn btn-success" href="{% url 'snsapp:follow-profile' user.username %}" role="button">フォロー</a>
                 {% endif %}
             {% endif %}
-
         {% endfor %}
 
     </div>
 </div>
+
+<div class="container mt-3" role="alert">
+    {% for post in posts %}
+    <div class="alert alert-success" role="alert">
+        <p>タイトル：{{post.title}}</p>
+        <p>投稿者：<a href="{% url 'snsapp:profile' post.user.username %}">{{post.user.username}}</a></p>
+
+        {% if request.user in post.like_users.all %}
+        <a class="like-btn add-color" href="{% url 'snsapp:like-home' post.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>
+        {% else %}
+        <a class="like-btn" href="{% url 'snsapp:like-home' post.pk %}" tabindex="-1" role="button" aria-disabled="true"><i class="bi bi-heart-fill"></i></a>
+        {% endif %}
+
+        <a class="btn btn-primary" href="{% url 'snsapp:detail' post.pk %}" role="button">詳細</a>
+
+        <button type="button" class="btn btn-danger dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">いいね {{post.like_users.count}}</button>
+        <ul class="dropdown-menu">
+            <!-- いいねしたユーザが１人でもいる場合 -->
+            {% if post.like_users.all %}
+                <!-- 全員の名前を表示 -->
+                {% for user in post.like_users.all %}
+                <li><a class="dropdown-item" href="#">{{user.username}}</a></li>
+                {% endfor %}
+            <!-- いいねしたユーザが１人もいない場合 -->
+            {% else %}
+                <li><a class="dropdown-item">いいねした人はいません</a></li>
+            {% endif %}
+        </ul>
+    </div>
+    {% endfor %}
+
+</div>
+
 {% endblock content %}


### PR DESCRIPTION
# やったこと

プロフィールページに投稿を表示する機能の実装．

# 目的

プロフィールのみを表示すると情報量が少なく，味気なくなってしまうため．また，特定のユーザの投稿のみをすべて表示するページが他にないため．

# できるようになったこと

- プロフィールページでの投稿閲覧
- プロフィールページでの投稿へのいいね

# できなくなったこと

- 特になし

# 動作確認

プロフィールページで投稿が見られることを確認した．また，いいねボタンを押したときの遷移先がプロフィールページになっていることも確認できた．

# 懸念点

特になし．