### PR TITLE
feat: change to display nickname and icon on posts if they are regist…

### DIFF
--- a/templates/list.html
+++ b/templates/list.html
@@ -10,8 +10,19 @@
 <div class="container mt-3">
     {% for item in object_list %}
     <div class="alert alert-success" role="alert">
-        <p>タイトル：{{item.title}}</p>
-        <p>投稿者：<a href="{% url 'snsapp:profile' item.user.username %}">{{item.user.username}}</a>
+        <p>
+            タイトル：{{item.title}}
+        </p>
+        <p>
+            投稿者：
+            <!-- ニックネームがある場合はそれを表示 -->
+            {% if item.user.nickname %}
+                <a href="{% url 'snsapp:profile' item.user.username %}">{{item.user.nickname}}</a>
+            <!-- ない場合はユーザ名を表示 -->
+            {% else %}
+                <a href="{% url 'snsapp:profile' item.user.username %}">{{item.user.username}}</a>
+            {% endif %}
+            <!-- アイコン画像がある場合は表示 -->
             {% if item.user.image %}
             <img src="{{item.user.image.url}}" width="30" height="30">
             {% endif %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -60,8 +60,23 @@
 <div class="container mt-3" role="alert">
     {% for post in posts %}
     <div class="alert alert-success" role="alert">
-        <p>タイトル：{{post.title}}</p>
-        <p>投稿者：{{post.user.username}}</p>
+        <p>
+            タイトル：{{post.title}}
+        </p>
+        <p>
+            投稿者：
+            <!-- ニックネームがある場合はそれを表示 -->
+            {% if post.user.nickname %}
+                {{post.user.nickname}}
+            <!-- ない場合はユーザ名を表示 -->
+            {% else %}
+                {{post.user.username}}
+            {% endif %}
+            <!-- アイコン画像がある場合は表示 -->
+            {% if post.user.image %}
+            <img src="{{post.user.image.url}}" width="30" height="30">
+            {% endif %}
+        </p>
 
         {% if request.user != post.user %}
             {% if request.user in post.like_users.all %}


### PR DESCRIPTION
# やったこと

ニックネームやアイコンが登録されている場合は投稿に表示し，未登録の場合はニックネームの代わりにユーザ名を表示するようにした．ただし，アイコンが未登録の場合は何も表示しない．

# 目的

ニックネームを登録していても投稿にはユーザ名が表示されている状態で，ニックネームの存在意義が薄れていたため．

# できるようになったこと

- 投稿でのニックネーム・アイコンの表示

# できなくなったこと

- 特になし

# 動作確認

ニックネームが登録されているユーザについては投稿にニックネームが表示され，未登録のユーザの投稿にはユーザ名が表示されていることを実際に確認した．また，アイコンについては登録されている場合のみ表示されていることが確認できた．

# 懸念点

デフォルトアイコンの設定が必要だと感じた．