### PR TITLE
fix: fix to be able to display the line breaks typed in the body of t…

### DIFF
--- a/templates/detail.html
+++ b/templates/detail.html
@@ -11,7 +11,7 @@
     <div class="alert alert-success" role="alert">
         <p>タイトル：{{object.title}}</p>
         <p>投稿者：<a href="{% url 'snsapp:profile' object.user.username %}">{{object.user.username}}</a></p>
-        <P>本文：{{object.content}}</P>
+        <P>本文：{{object.content | linebreaksbr}}</P>
         {% if object.image %}
             <p>画像：{{object.image}}</p>
         {% endif %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -29,7 +29,7 @@
             <p>
                 自己紹介：
                 {% if user.introduction %}
-                    {{user.introduction}}
+                    {{user.introduction | linebreaksbr}}
                 {% else %}
                     よろしくお願いします．
                 {% endif %}


### PR DESCRIPTION
# やったこと

投稿の本文とプロフィールの自己紹介での改行をページに反映させた．

# 目的

文章を一旦切りたい場合に改行が反映されないと不便なため．

# できるようになったこと

- 投稿の本文とプロフィールの自己紹介での改行の表示

# できなくなったこと

- 特になし

# 動作確認

実際に改行を含む自己紹介と投稿をして，改行が正しく表示されていることが確認できた．

# 懸念点

"自己紹介："や"本文："の部分は必ず1行目に表示されてしまうため，2行目以降と左右の位置がずれてしまう．そのため，自己紹介と本文だけは1行下げたところから文章を表示した方が良いかもしれない．全体のレイアウトを考慮しながら方法を考える．